### PR TITLE
Fix broken relative link to helm.h in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ helm
 ![Controller block diagram](helm.png)
 
 This proportional-integral-derivative (PID) controller, implemented wholly
-within [helm.h], features:
+within [helm.h](helm.h), features:
  * low pass filtering of the process derivative,
  * windup protection,
  * automatic reset on actuator saturation,


### PR DESCRIPTION
## Summary

- Fix the broken `[helm.h]` link in README.md by converting it from a reference-style link (with no corresponding reference definition) to an inline link `[helm.h](helm.h)`

Fixes #4

---
_Generated by [Claude Code](https://claude.ai/code/session_018zEK5Mcmv3Jxwa5oupMfT4)_