### PR TITLE
Fix typo in helm.c and document why the file exists

### DIFF
--- a/helm.c
+++ b/helm.c
@@ -9,7 +9,12 @@
 //--------------------------------------------------------------------------
 
 /** \file
- * C99 extern declarations for state inline functions within \ref helm.h
+ * C99 extern declarations for static inline functions within \ref helm.h
+ *
+ * When a header-only library uses static inline, each translation unit
+ * gets its own private copy.  Providing matching extern declarations in
+ * a single .c file lets the compiler emit one shared, externally-visible
+ * definition that the linker can use when inlining is not performed.
  */
 
 #include "helm.h"


### PR DESCRIPTION
## Summary

- Fix typo on line 12: "state inline functions" → "static inline functions"
- Add 3-line Doxygen comment explaining why `helm.c` exists in a header-only library (it provides `extern` declarations so the compiler can emit one shared, externally-visible definition when inlining is not performed)

Fixes #5

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ko7PZLc1ybcNdBacWxSich)_