### PR TITLE
Remove stale FIXMEs in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ clean:
 
 ###################################################################
 # Build Graphviz-based block diagram
-# FIXME Require version after 14 October 2011
 ###################################################################
 DOT ?= $(shell which dot)
 ifneq "$(DOT)" ""

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,6 @@ endif
 
 ###################################################################
 # Build Doxygen
-# FIXME Require version 1.8.3+ for full Markdown support
 ###################################################################
 DOXYGEN ?= $(shell which doxygen)
 ifneq "$(DOXYGEN)" ""


### PR DESCRIPTION
## Summary

- Remove the stale FIXME about requiring a Graphviz version after October 2011 (line 19)
- Remove the stale FIXME about requiring Doxygen 1.8.3+ for Markdown support (line 33)

Both version checks were never implemented and the referenced versions are long since ubiquitous.

Closes #6

---
_Generated by [Claude Code](https://claude.ai/code/session_017BxMX2ycuVkZo9L8WPV6ez)_