### PR TITLE
Build and publish Doxygen docs via CircleCI

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -1,0 +1,54 @@
+# CircleCI Configuration
+
+This directory contains the CircleCI configuration for automated testing and
+documentation deployment.
+
+## Jobs
+
+### `test`
+
+Builds `helm.o` and `step3` across the Ubuntu image matrix to verify the code
+compiles cleanly.
+
+### `deploy-docs`
+
+Builds Doxygen documentation then deploys it to the `gh-pages` branch on GitHub
+Pages.  This job only runs on the `master` branch after all tests pass.
+
+## GitHub Pages Deployment Setup
+
+To enable automatic documentation deployment, configure the following in your
+CircleCI project settings:
+
+### Required Environment Variables
+
+Add these environment variables in CircleCI Project Settings → Environment
+Variables:
+
+1. **GH_NAME**: Your GitHub username or bot name for commits
+   - Example: `CircleCI Documentation Bot`
+
+2. **GH_EMAIL**: Email address for documentation commits
+   - Example: `ci-bot@example.com`
+
+3. **GH_TOKEN**: GitHub Personal Access Token with `repo` scope
+   - Allows CircleCI to push to the `gh-pages` branch
+   - Create at: https://github.com/settings/tokens
+   - Required permissions: This repository only, Content, Read-Write
+
+### GitHub Repository Setup
+
+1. The `gh-pages` branch will be automatically created on first deployment
+
+2. After the first deployment, enable GitHub Pages in repository settings:
+   - Go to Settings → Pages
+   - Source: Deploy from a branch
+   - Branch: `gh-pages` / `root`
+
+3. Your documentation will be available at:
+   `https://rhysu.github.io/helm/`
+
+### Security Note
+
+The `GH_TOKEN` should be kept secret. Never commit it to the repository.
+CircleCI environment variables are encrypted and not exposed in build logs.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,65 @@
+version: 2.1
+
+executors:
+  ubuntu-docker:
+    parameters:
+      version:
+        type: string
+    docker:
+      - image: cimg/base:<< parameters.version >>
+    resource_class: small
+
+jobs:
+  test:
+    parameters:
+      version:
+        type: string
+    executor:
+      name: ubuntu-docker
+      version: << parameters.version >>
+    resource_class: medium
+    steps:
+      - checkout
+      - run:
+          name: Build
+          command: make helm.o step3
+
+  deploy-docs:
+    executor:
+      name: ubuntu-docker
+      version: current
+    resource_class: small
+    steps:
+      - checkout
+      - run:
+          name: Install Doxygen and Graphviz
+          command: |
+            sudo apt-get update -qq
+            sudo apt-get install -yqq doxygen graphviz
+      - run:
+          name: Build documentation
+          command: |
+            doxygen Doxyfile
+      - run:
+          name: Deploy to gh-pages
+          command: |
+            if [ "${CIRCLE_BRANCH}" = "master" ]; then
+              ./.circleci/deploy-ghpages.sh html
+            else
+              echo "Skipping deploy (not on master)"
+            fi
+
+workflows:
+  build-and-deploy:
+    jobs:
+      - test:
+          matrix:
+            parameters:
+              version:
+                - current
+      - deploy-docs:
+          requires:
+            - test
+          filters:
+            branches:
+              only: master

--- a/.circleci/deploy-ghpages.sh
+++ b/.circleci/deploy-ghpages.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -eu
+
+SOURCE_DIR="${1:-html}"
+if [ ! -d "$SOURCE_DIR" ]; then
+    echo "Error: Source directory $SOURCE_DIR does not exist"
+    exit 1
+fi
+
+git config --global user.email "${GH_EMAIL}"
+git config --global user.name "${GH_NAME}"
+
+TEMP_DIR=$(mktemp -d)
+trap "rm -rf '$TEMP_DIR'" EXIT
+cd "$TEMP_DIR"
+
+git init -b gh-pages
+
+cp -R "${CIRCLE_WORKING_DIRECTORY}/${SOURCE_DIR}"/* .
+
+touch .nojekyll
+
+git add -A
+git commit -m "Deploy documentation to GitHub Pages [ci skip]
+
+Built from commit ${CIRCLE_SHA1} on branch ${CIRCLE_BRANCH}"
+
+git remote add origin "https://${GH_TOKEN}@github.com/${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
+
+echo "Pushing to gh-pages branch..."
+git push --force --quiet origin gh-pages > /dev/null 2>&1
+
+echo "Documentation deployed successfully to gh-pages"

--- a/Doxyfile
+++ b/Doxyfile
@@ -1469,7 +1469,7 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = http://cdn.mathjax.org/mathjax/latest
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2/
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example
@@ -1580,7 +1580,7 @@ EXTRA_SEARCH_MAPPINGS  =
 # If the GENERATE_LATEX tag is set to YES, doxygen will generate LaTeX output.
 # The default value is: YES.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The LATEX_OUTPUT tag is used to specify where the LaTeX docs will be put. If a
 # relative path is entered the value of OUTPUT_DIRECTORY will be put in front of
@@ -2118,7 +2118,7 @@ HIDE_UNDOC_RELATIONS   = YES
 # set to NO
 # The default value is: YES.
 
-HAVE_DOT               = NO
+HAVE_DOT               = YES
 
 # The DOT_NUM_THREADS specifies the number of dot invocations doxygen is allowed
 # to run in parallel. When set to 0 doxygen will base this on the number of

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 helm
 ====
 
+Project home: https://github.com/RhysU/helm
+
+API documentation: https://rhysu.github.io/helm/
+
 ![Controller block diagram](helm.png)
 
 This proportional-integral-derivative (PID) controller, implemented wholly


### PR DESCRIPTION
## Summary

- Add CircleCI configuration (`.circleci/`) following the [underling CI patterns](https://github.com/RhysU/underling/tree/master/.circleci): a `test` job that compiles `helm.o` and `step3`, and a `deploy-docs` job that builds Doxygen HTML and deploys to `gh-pages` on master
- Fix MathJax CDN from `http://cdn.mathjax.org` (defunct) to `https://cdn.jsdelivr.net/npm/mathjax@2/` — enforces HTTPS and restores math rendering
- Enable `HAVE_DOT` in Doxyfile so Graphviz diagrams render in the docs
- Disable LaTeX output (not needed for web-hosted docs)
- Add project home and API documentation links to README.md

## Setup required

After merging, configure these CircleCI environment variables (see `.circleci/README.md`):
- `GH_NAME` — commit author name for docs deploys
- `GH_EMAIL` — commit author email
- `GH_TOKEN` — GitHub personal access token with repo Content read-write scope

Then enable GitHub Pages in repo Settings → Pages → Branch: `gh-pages` / `root`.

Closes #3

---
_Generated by [Claude Code](https://claude.ai/code/session_01QvFxZMRGsxUHvBYzqCpPnp)_