### PR TITLE
Initialize h->y to NAN in helm_approach function

### DIFF
--- a/helm.h
+++ b/helm.h
@@ -226,6 +226,7 @@ helm_approach(struct helm_state * const h)
     assert(h->Tf >  0);
     assert(h->Ti >  0);
     assert(h->Tt >  0);
+    h->y = NAN;
     h->f = NAN;
     return h;
 }


### PR DESCRIPTION
## Summary
Added initialization of the `h->y` field to `NAN` in the `helm_approach()` function to ensure consistent state initialization alongside the existing `h->f` initialization.

## Key Changes
- Initialize `h->y` to `NAN` before returning from `helm_approach()`
- Placed initialization immediately before the existing `h->f = NAN` assignment for consistency

## Implementation Details
This change ensures that the `y` field is explicitly set to `NAN` (Not-A-Number) during the approach state initialization, matching the pattern already established for the `f` field. This helps prevent undefined behavior and makes the initialization state explicit and predictable.

https://claude.ai/code/session_01V1daLJ4VGCFacn8bZ6kfHU