### PR TITLE
Upgrade MathJax configuration from v2 to v3

### DIFF
--- a/Doxyfile
+++ b/Doxyfile
@@ -1448,6 +1448,8 @@ FORMULA_TRANSPARENT    = YES
 
 USE_MATHJAX            = YES
 
+MATHJAX_VERSION        = MathJax_3
+
 # When MathJax is enabled you can set the default output format to be used for
 # the MathJax output. See the MathJax site (see:
 # http://docs.mathjax.org/en/latest/output.html) for more details.
@@ -1456,7 +1458,7 @@ USE_MATHJAX            = YES
 # The default value is: HTML-CSS.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_FORMAT         = HTML-CSS
+MATHJAX_FORMAT         = chtml
 
 # When MathJax is enabled you need to specify the location relative to the HTML
 # output directory using the MATHJAX_RELPATH option. The destination directory
@@ -1469,15 +1471,14 @@ MATHJAX_FORMAT         = HTML-CSS
 # The default value is: http://cdn.mathjax.org/mathjax/latest.
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@2/
+MATHJAX_RELPATH        = https://cdn.jsdelivr.net/npm/mathjax@3
 
 # The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
 # extension names that should be enabled during MathJax rendering. For example
 # MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
 # This tag requires that the tag USE_MATHJAX is set to YES.
 
-MATHJAX_EXTENSIONS     = TeX/AMSmath \
-                         TeX/AMSsymbols
+MATHJAX_EXTENSIONS     = ams
 
 # The MATHJAX_CODEFILE tag can be used to specify a file with javascript pieces
 # of code that will be used on startup of the MathJax code. See the MathJax site


### PR DESCRIPTION
## Summary
Updated the Doxyfile configuration to use MathJax version 3 instead of version 2, including all necessary configuration changes for compatibility with the newer version.

## Key Changes
- Added `MATHJAX_VERSION = MathJax_3` configuration option
- Updated `MATHJAX_FORMAT` from `HTML-CSS` to `chtml` (the default output format for MathJax 3)
- Updated `MATHJAX_RELPATH` from `https://cdn.jsdelivr.net/npm/mathjax@2/` to `https://cdn.jsdelivr.net/npm/mathjax@3`
- Simplified `MATHJAX_EXTENSIONS` from `TeX/AMSmath TeX/AMSsymbols` to `ams` (the MathJax 3 equivalent)

## Implementation Details
These changes align with MathJax 3's updated configuration API and CDN structure. The `chtml` format replaces the older `HTML-CSS` output format, and the extension syntax has been simplified in MathJax 3 where `ams` provides the combined functionality of the previous separate AMSmath and AMSsymbols extensions.

https://claude.ai/code/session_017bFvbp89WrGnWxwskrDCUJ